### PR TITLE
Downgrade Go version to 1.20

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.20', '>=1.21' ]
 
     services:
       sqld:
@@ -28,6 +31,7 @@ jobs:
         with:
           go-version-file: "go.mod"
           cache: true
+          go-version: ${{ matrix.go }}
 
       - name: Format
         run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/libsql/libsql-client-go
 
-go 1.21
+go 1.20
 
 require (
 	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230512164433-5d1fd1a340c9

--- a/libsql/sql.go
+++ b/libsql/sql.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"strings"
 
 	"github.com/libsql/libsql-client-go/libsql/internal/http"
@@ -78,7 +77,7 @@ func (c config) connector(dbPath string) (driver.Connector, error) {
 		expectedDrivers := []string{"sqlite", "sqlite3"}
 		presentDrivers := sql.Drivers()
 		for _, expectedDriver := range expectedDrivers {
-			if slices.Contains(presentDrivers, expectedDriver) {
+			if Contains(presentDrivers, expectedDriver) {
 				db, err := sql.Open(expectedDriver, dbPath)
 				if err != nil {
 					return nil, err
@@ -274,7 +273,7 @@ func (d Driver) Open(dbUrl string) (driver.Conn, error) {
 		expectedDrivers := []string{"sqlite", "sqlite3"}
 		presentDrivers := sql.Drivers()
 		for _, expectedDriver := range expectedDrivers {
-			if slices.Contains(presentDrivers, expectedDriver) {
+			if Contains(presentDrivers, expectedDriver) {
 				db, err := sql.Open(expectedDriver, dbUrl)
 				if err != nil {
 					return nil, err
@@ -331,4 +330,19 @@ func (d Driver) Open(dbUrl string) (driver.Conn, error) {
 
 func init() {
 	sql.Register("libsql", Driver{})
+}
+
+// backported from Go 1.21
+
+func Contains[S ~[]E, E comparable](s S, v E) bool {
+	return Index(s, v) >= 0
+}
+
+func Index[S ~[]E, E comparable](s S, v E) int {
+	for i := range s {
+		if v == s[i] {
+			return i
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
Goose is a pretty slick migration tool and I am trying to add Turso support to it. I have opened a PR here - https://github.com/pressly/goose/pull/658

However, goose minimum go version requirement is 1.19 and maintainers do not want to increase it to 1.21 just for Turso, which is reasonable. But they are fine merging if the version is 1.20.

In our library, we only use `slice.Contains` function, so I have back ported those and reduced the min version to 1.20