### PR TITLE
feat: Add ping ability

### DIFF
--- a/examples/sql/counter/main.go
+++ b/examples/sql/counter/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"os"
 	"sync"
 
@@ -151,7 +152,10 @@ func runCounterExample(dbPath string) {
 		os.Exit(1)
 	}
 	// Defer a rollback in case anything fails.
-	defer tx.Rollback()
+	defer func() {
+		err := tx.Rollback()
+		log.Fatal(err)
+	}()
 	rows = queryTx(ctx, tx, `SELECT * FROM counter WHERE (country = "PL" AND city = "WAW") OR (country = "FI" AND city = "HEL")`)
 	wawValue := -1
 	helValue := -1

--- a/libsql/internal/http/hranaV2/hranaV2.go
+++ b/libsql/internal/http/hranaV2/hranaV2.go
@@ -89,6 +89,15 @@ type hranaV2Conn struct {
 	streamClosed bool
 }
 
+func (h *hranaV2Conn) Ping() error {
+	return h.PingContext(context.Background())
+}
+
+func (h *hranaV2Conn) PingContext(ctx context.Context) error {
+	_, err := h.executeStmt(ctx, "SELECT 1", nil, false)
+	return err
+}
+
 func (h *hranaV2Conn) Prepare(query string) (driver.Stmt, error) {
 	return h.PrepareContext(context.Background(), query)
 }

--- a/libsql/internal/ws/driver.go
+++ b/libsql/internal/ws/driver.go
@@ -101,6 +101,15 @@ func (s stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (drive
 	return s.c.QueryContext(ctx, s.query, args)
 }
 
+func (c *conn) Ping() error {
+	return c.PingContext(context.Background())
+}
+
+func (c *conn) PingContext(ctx context.Context) error {
+	_, err := c.ws.exec(ctx, "SELECT 1", params{}, false)
+	return err
+}
+
 func (c *conn) Prepare(query string) (driver.Stmt, error) {
 	return c.PrepareContext(context.Background(), query)
 }

--- a/tests/http/driver_test.go
+++ b/tests/http/driver_test.go
@@ -239,6 +239,24 @@ func (t Tx) prepareInsertStmt() PreparedStmt {
 	return PreparedStmt{stmt, t.t}
 }
 
+func TestPing(t *testing.T) {
+	t.Parallel()
+	db := getDb(T{t})
+
+	// This ping should succeed because the database is up and running
+	db.t.FatalOnError(db.Ping())
+
+	t.Cleanup(func() {
+		db.Close()
+
+		// This ping should return an error because the database is already closed
+		err := db.Ping()
+		if err == nil {
+			db.t.Fatal("db.Ping succeeded when it should have failed")
+		}
+	})
+}
+
 func TestExecAndQuery(t *testing.T) {
 	t.Parallel()
 	db := getDb(T{t})

--- a/tests/ws/driver_test.go
+++ b/tests/ws/driver_test.go
@@ -70,6 +70,26 @@ func assertRows(ctx context.Context, t *testing.T, db *sql.DB) {
 	}
 }
 
+func TestPing(t *testing.T) {
+	ctx := context.Background()
+	db := setupDB(ctx, t)
+
+	// This ping should succeed because the database is up and running
+	err := db.PingContext(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cleanupDB(ctx, t, db)
+		// This ping should return an error because the database is already closed
+		err = db.PingContext(ctx)
+		if err == nil {
+			t.Fatal("db.Ping succeeded when it should have failed")
+		}
+	})
+
+}
+
 func TestQueryExec(t *testing.T) {
 	ctx := context.Background()
 	db := setupDB(ctx, t)


### PR DESCRIPTION
This PR adds a Ping and PingContext method to the Driver which satisfy the sql driver interface.

It uses a simple SELECT 1 to test the connection, which I believe is how most drivers implement a ping.

I have added a test to test the funcitonality and also included an example.

Closes #96 