### PR TITLE
Value Base64 should be a pointer to allow empty blobs

### DIFF
--- a/libsql/internal/hrana/value.go
+++ b/libsql/internal/hrana/value.go
@@ -9,8 +9,8 @@ import (
 )
 
 type Value struct {
-	Type   string `json:"type"`
-	Value  any    `json:"value,omitempty"`
+	Type   string  `json:"type"`
+	Value  any     `json:"value,omitempty"`
 	Base64 *string `json:"base64,omitempty"`
 }
 

--- a/libsql/internal/hrana/value.go
+++ b/libsql/internal/hrana/value.go
@@ -11,12 +11,15 @@ import (
 type Value struct {
 	Type   string `json:"type"`
 	Value  any    `json:"value,omitempty"`
-	Base64 string `json:"base64,omitempty"`
+	Base64 *string `json:"base64,omitempty"`
 }
 
 func (v Value) ToValue(columnType *string) any {
 	if v.Type == "blob" {
-		bytes, err := base64.StdEncoding.WithPadding(base64.NoPadding).DecodeString(v.Base64)
+		if v.Base64 == nil {
+			return nil
+		}
+		bytes, err := base64.StdEncoding.WithPadding(base64.NoPadding).DecodeString(*v.Base64)
 		if err != nil {
 			return nil
 		}
@@ -65,7 +68,8 @@ func ToValue(v any) (Value, error) {
 		res.Value = text
 	} else if blob, ok := v.([]byte); ok {
 		res.Type = "blob"
-		res.Base64 = base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString(blob)
+		b64 := base64.StdEncoding.WithPadding(base64.NoPadding).EncodeToString(blob)
+		res.Base64 = &b64
 	} else if float, ok := v.(float64); ok {
 		res.Type = "float"
 		res.Value = float

--- a/libsql/internal/hrana/value_test.go
+++ b/libsql/internal/hrana/value_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 )
-	
+
 func toPtr[T any](v T) *T {
 	return &v
 }

--- a/libsql/internal/hrana/value_test.go
+++ b/libsql/internal/hrana/value_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 	"time"
 )
+	
+func toPtr[T any](v T) *T {
+	return &v
+}
 
 func TestValueToValue(t *testing.T) {
 	tests := []struct {
@@ -43,9 +47,17 @@ func TestValueToValue(t *testing.T) {
 			name: "bytes",
 			value: Value{
 				Type:   "blob",
-				Base64: "YmFy",
+				Base64: toPtr("YmFy"),
 			},
 			want: []byte("bar"),
+		},
+		{
+			name: "bytes",
+			value: Value{
+				Type:   "blob",
+				Base64: toPtr(""),
+			},
+			want: []byte{},
 		},
 		{
 			name: "float",
@@ -111,10 +123,10 @@ func TestToValue(t *testing.T) {
 		},
 		{
 			name:  "bytes",
-			value: []byte("bar"),
+			value: []byte{},
 			want: Value{
 				Type:   "blob",
-				Base64: "YmFy",
+				Base64: toPtr(""),
 			},
 		},
 		{
@@ -195,7 +207,7 @@ func TestMarshal(t *testing.T) {
 			name: "bytes",
 			value: Value{
 				Type:   "blob",
-				Base64: "YmFy",
+				Base64: toPtr("YmFy"),
 			},
 			marshaled: `{"type":"blob","base64":"YmFy"}`,
 		},
@@ -263,7 +275,7 @@ func TestUnmarshal(t *testing.T) {
 			name: "bytes",
 			value: Value{
 				Type:   "blob",
-				Base64: "YmFy",
+				Base64: toPtr("YmFy"),
 			},
 			marshaled: `{"type":"blob","base64":"YmFy"}`,
 		},


### PR DESCRIPTION
While trying to insert an empty slice in a blob, I kept getting the same error;

```
missing field `base64`
```

While reading the library code, I noticed that if Base64 was and empty string `""`, due to `omitempty`, it was not marshalled.

Which caused the issue.

---

The fix is to simply make Base64 into a pointer. That means for the blob type, the pointer will not be `nil` and will be marshalled.