### PR TITLE
add support for boolean in ws stmt arguments payload

### DIFF
--- a/libsql/internal/ws/websockets.go
+++ b/libsql/internal/ws/websockets.go
@@ -55,6 +55,13 @@ func convertValue(v any) (map[string]interface{}, error) {
 	} else if float, ok := v.(float64); ok {
 		res["type"] = "float"
 		res["value"] = float
+	} else if boolean, ok := v.(bool); ok {
+		res["type"] = "integer"
+		if boolean {
+			res["value"] = "1"
+		} else {
+			res["value"] = "0"
+		}
 	} else {
 		return nil, fmt.Errorf("unsupported value type: %s", v)
 	}

--- a/libsql/internal/ws/websockets_test.go
+++ b/libsql/internal/ws/websockets_test.go
@@ -59,6 +59,24 @@ func TestConvertValue(t *testing.T) {
 			err: nil,
 		},
 		{
+			name:  "boolean_true",
+			value: true,
+			want: map[string]any{
+				"type":  "integer",
+				"value": "1",
+			},
+			err: nil,
+		},
+		{
+			name:  "boolean_false",
+			value: false,
+			want: map[string]any{
+				"type":  "integer",
+				"value": "0",
+			},
+			err: nil,
+		},
+		{
 			name:  "unsupported",
 			value: struct{}{},
 			want:  nil,


### PR DESCRIPTION
This adds support for passing down bool in queries.

```go
db.ExecContext(ctx, "INSERT INTO people (id, cool_guy) VALUES (?, ?)", 1, true)
db.ExecContext(ctx, "INSERT INTO people (id, cool_guy) VALUES (?, ?)", 1, false)
```
previously it would spit out a error. "unsupported value type: %!s(bool=false) (string)"