### PR TITLE
Make it possible to signal to the driver that we're connecting to schema db and use nontransactional batches in such case

### DIFF
--- a/libsql/internal/http/driver.go
+++ b/libsql/internal/http/driver.go
@@ -6,6 +6,6 @@ import (
 	"github.com/tursodatabase/libsql-client-go/libsql/internal/http/hranaV2"
 )
 
-func Connect(url, jwt, host string) driver.Conn {
-	return hranaV2.Connect(url, jwt, host)
+func Connect(url, jwt, host string, schemaDb bool) driver.Conn {
+	return hranaV2.Connect(url, jwt, host, schemaDb)
 }

--- a/libsql/internal/http/hranaV2/hranaV2.go
+++ b/libsql/internal/http/hranaV2/hranaV2.go
@@ -299,7 +299,7 @@ func (h *hranaV2Conn) executeStmt(ctx context.Context, query string, args []driv
 		}
 		msg.Add(*executeStream)
 	} else {
-		batchStream, err := hrana.BatchStream(stmts, params, wantRows)
+		batchStream, err := hrana.BatchStream(stmts, params, wantRows, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to execute SQL: %s\n%w", query, err)
 		}

--- a/libsql/internal/http/hranaV2/hranaV2.go
+++ b/libsql/internal/http/hranaV2/hranaV2.go
@@ -299,7 +299,7 @@ func (h *hranaV2Conn) executeStmt(ctx context.Context, query string, args []driv
 		}
 		msg.Add(*executeStream)
 	} else {
-		batchStream, err := hrana.BatchStream(stmts, params, wantRows, true)
+		batchStream, err := hrana.BatchStream(stmts, params, wantRows, !h.schemaDb)
 		if err != nil {
 			return nil, fmt.Errorf("failed to execute SQL: %s\n%w", query, err)
 		}
@@ -339,7 +339,11 @@ func (h *hranaV2Conn) ExecContext(ctx context.Context, query string, args []driv
 		}
 		lastInsertRowId := int64(0)
 		affectedRowCount := int64(0)
-		for idx := 0; idx < len(res.StepResults)-1; idx++ {
+		upperBound := len(res.StepResults)
+		if !h.schemaDb {
+			upperBound -= 1
+		}
+		for idx := 0; idx < upperBound; idx++ {
 			r := res.StepResults[idx]
 			rowId := r.GetLastInsertRowId()
 			if rowId > 0 {
@@ -459,8 +463,10 @@ func (h *hranaV2Conn) QueryContext(ctx context.Context, query string, args []dri
 		if err != nil {
 			return nil, err
 		}
-		res.StepResults = res.StepResults[:len(res.StepResults)-1]
-		res.StepErrors = res.StepErrors[:len(res.StepErrors)-1]
+		if !h.schemaDb {
+			res.StepResults = res.StepResults[:len(res.StepResults)-1]
+			res.StepErrors = res.StepErrors[:len(res.StepErrors)-1]
+		}
 		return shared.NewRows(&BatchResultRowsProvider{res}), nil
 	default:
 		return nil, fmt.Errorf("failed to execute SQL: %s\n%s", query, "unknown response type")

--- a/libsql/internal/http/hranaV2/hranaV2.go
+++ b/libsql/internal/http/hranaV2/hranaV2.go
@@ -36,8 +36,8 @@ func init() {
 	commitHash = "unknown"
 }
 
-func Connect(url, jwt, host string) driver.Conn {
-	return &hranaV2Conn{url, jwt, host, "", false, 0}
+func Connect(url, jwt, host string, schemaDb bool) driver.Conn {
+	return &hranaV2Conn{url, jwt, host, schemaDb, "", false, 0}
 }
 
 type hranaV2Stmt struct {
@@ -85,6 +85,7 @@ type hranaV2Conn struct {
 	url              string
 	jwt              string
 	host             string
+	schemaDb         bool
 	baton            string
 	streamClosed     bool
 	replicationIndex uint64


### PR DESCRIPTION
Schema migrations fail if they consist a transaction so we need to make sure that a batch sent to a schema db is not transactional. Otherwise the operation fails with:

```
Schema migration error: migration is invalid: it contains transaction items (BEGIN, COMMIT, SAVEPOINT...) which are not allowed. The migration is already run within a transaction
```