### PR TITLE
Update go.mod to reflect new owner of websocket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.0
 	golang.org/x/sync v0.3.0
-	nhooyr.io/websocket v1.8.10
+	github.com/coder/websocket v1.8.12
 )
 
 require golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8 // indirect


### PR DESCRIPTION
websocket's new owner: github.com/coder/ ?
only available version: 1.8.12

People unable to go install the turso cli for Go led me to this due to 1.8.10 of nhooyr.io/websocket not existing and in fact now redirects to github.com/coder/websocket who's only available release is 1.8.12