### PR TITLE
Remove pipeline request 60s timeout

### DIFF
--- a/libsql/internal/http/hranaV2/hranaV2.go
+++ b/libsql/internal/http/hranaV2/hranaV2.go
@@ -13,7 +13,6 @@ import (
 	net_url "net/url"
 	"runtime/debug"
 	"strings"
-	"time"
 
 	"github.com/tursodatabase/libsql-client-go/libsql/internal/hrana"
 	"github.com/tursodatabase/libsql-client-go/libsql/internal/http/shared"
@@ -235,8 +234,6 @@ func sendPipelineRequest(ctx context.Context, msg *hrana.PipelineRequest, url st
 	if err != nil {
 		return hrana.PipelineResponse{}, false, err
 	}
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
-	defer cancel()
 	pipelineURL, err := net_url.JoinPath(url, "/v2/pipeline")
 	if err != nil {
 		return hrana.PipelineResponse{}, false, err


### PR DESCRIPTION
Callers should control their timeouts by calling with the appropriate context.
Enforcing a fixed timeout can get in the way of expensive queries and migrations.