### PR TITLE
fix: set Content-Type header on Hrana HTTP requests

### DIFF
--- a/libsql/internal/http/hranaV2/hranaV2.go
+++ b/libsql/internal/http/hranaV2/hranaV2.go
@@ -249,6 +249,7 @@ func sendPipelineRequest(ctx context.Context, msg *hrana.PipelineRequest, url st
 	if len(jwt) > 0 {
 		req.Header.Set("Authorization", "Bearer "+jwt)
 	}
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-libsql-client-version", "libsql-remote-go-"+commitHash)
 	if remoteEncryptionKey != "" {
 		req.Header.Set("x-turso-encryption-key", remoteEncryptionKey)


### PR DESCRIPTION
The `sendPipelineRequest` function in `libsql/internal/http/hranaV2/hranaV2.go` does not set a `Content-Type` header on POST requests. Some reverse proxies mangle JSON bodies when the header is missing, causing servers to return 400 errors.

This adds `Content-Type: application/json` to the request headers.